### PR TITLE
PropTypes

### DIFF
--- a/src/Footer.js
+++ b/src/Footer.js
@@ -7,7 +7,7 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { observer } from 'mobx-react';
 import { extendObservable } from 'mobx';

--- a/src/Footer.js
+++ b/src/Footer.js
@@ -8,6 +8,7 @@
  */
 
 import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import { observer } from 'mobx-react';
 import { extendObservable } from 'mobx';
 

--- a/src/Item.js
+++ b/src/Item.js
@@ -7,7 +7,8 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { observer } from 'mobx-react';
 
 const Item = observer(class Item extends Component {

--- a/src/List.js
+++ b/src/List.js
@@ -7,7 +7,8 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { observer } from 'mobx-react';
 import Item from './Item';
 


### PR DESCRIPTION
i think PropTypes must be separated from React, because in version 15+, the PropTypes has its own library